### PR TITLE
Fix test return value in same-live.sh

### DIFF
--- a/test-scripts/same-live.sh
+++ b/test-scripts/same-live.sh
@@ -11,7 +11,7 @@ CHECK=$srcdir/test-scripts/check-live-pcap.sh
 do_check()
 {
     $CHECK $1 $2
-    checkres = $?
+    checkres=$?
     if [ $checkres -ne 0 ]; then
         echo "Checking $1 failed."
         exit $checkres


### PR DESCRIPTION
same-live.sh was always returning pass, even when an error was returned.

Reference: #28