### PR TITLE
Add limit to blocks in output file.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -38,6 +38,7 @@ check_SCRIPTS = test-scripts/check-config-info.sh \
                 test-scripts/check-outputs.sh \
                 test-scripts/check-testcontent.sh \
                 test-scripts/inspector-outputs.sh \
+                test-scripts/output-size-limit.sh \
                 test-scripts/same-output.sh \
                 test-scripts/same-output-gzip.sh \
                 test-scripts/same-output-xz.sh \

--- a/doc/compactor.adoc
+++ b/doc/compactor.adoc
@@ -186,7 +186,8 @@ example, to set the snap length to 64, the configuration file entry must read
 *-t, --rotation-period* _SECONDS_::
   Specify the frequency with which all output file path patterns should be re-examined.
   If the file path has changed, the existing output file is closed and a new one opened
-  using the new pattern expansion. The default period is 300 seconds.
+  using the new pattern expansion. If the file path has not changed, the pattern
+  is re-examined every second until it changes. The default period is 300 seconds.
 
 *-n, --include* _SECTIONS_::
   Indicate which optional sections should be included in the main output. This argument
@@ -209,6 +210,13 @@ example, to set the snap length to 64, the configuration file entry must read
    Set the maximum number of query/response items included in a single
    output C-DNS block. _arg_ must be a positive integer. The default maximum
    size is 5000.
+
+*--max-blocks-in-file* _arg_::
+   Set the maximum number of blocks to be included in a single output file before
+   the output file path pattern is re-examined. If the file path has changed, the existing
+   output file is closed and a new one opened. If the file path has not changed, the pattern
+   is re-examined every second until it changes. _arg_ must be a positive integer. The
+   default value is 0, which indicates there is no maximum number of blocks.
 
 ==== Query/response matching
 

--- a/doc/compactor.adoc
+++ b/doc/compactor.adoc
@@ -211,12 +211,14 @@ example, to set the snap length to 64, the configuration file entry must read
    output C-DNS block. _arg_ must be a positive integer. The default maximum
    size is 5000.
 
-*--max-blocks-in-file* _arg_::
-   Set the maximum number of blocks to be included in a single output file before
-   the output file path pattern is re-examined. If the file path has changed, the existing
-   output file is closed and a new one opened. If the file path has not changed, the pattern
-   is re-examined every second until it changes. _arg_ must be a positive integer. The
-   default value is 0, which indicates there is no maximum number of blocks.
+*--max-output-size* _arg_::
+   Sets a maximum size for the uncompressed output before an output file
+   rotation is triggered. _arg_ must be a positive integer, and may optionally
+   be followed by one of the following multiplicative suffixes: _k_=1024, _K_=1000,
+   _m_=1024*1024, _M_=1000*1000 and similarly for _g_, and _t_.
+   If a file rotation is triggered, the remaining block and the file postlude will
+   be written, so the final file size will exceed this setting by a small margin. The
+   default value is 0, which indicates there is no maximum size.
 
 ==== Query/response matching
 

--- a/doc/user-guide/configuring.adoc
+++ b/doc/user-guide/configuring.adoc
@@ -303,7 +303,8 @@ xz-preset-pcap=3
 *rotation-period*=_SECONDS_::
   Specify the frequency with which all output file path patterns should be re-examined.
   If the file path has changed, the existing output file is closed and a new one opened
-  using the new pattern expansion. The default period is 300 seconds.
+  using the new pattern expansion. If the file path has not changed, the pattern
+  is re-examined every second until it changes. The default period is 300 seconds.
 
 [source,ini]
 ----

--- a/etc/compactor.conf.in
+++ b/etc/compactor.conf.in
@@ -41,6 +41,12 @@
 # Output file rotation period, in seconds.
 # rotation-period=300
 
+# Maximum Query/Response records in a file block.
+# max-block-qr-items=5000
+
+# Maximum number of blocks in a file before rotation triggered. 0=no limit.
+# max-blocks-in-file=0
+
 # C-DNS output file pattern.
 # output=
 output=@DSLOCALSTATEDIR@/cdns/%Y%m%d-%H%M%S_%{rotate-period}_%{interface}.cdns

--- a/etc/compactor.conf.in
+++ b/etc/compactor.conf.in
@@ -44,8 +44,13 @@
 # Maximum Query/Response records in a file block.
 # max-block-qr-items=5000
 
-# Maximum number of blocks in a file before rotation triggered. 0=no limit.
-# max-blocks-in-file=0
+# Maximum size of uncompressed output before rotation triggered. 0=no limit.
+# Multiplicative suffices:
+#     k (1024), K (1000)
+#     m (1024*k), M (1000*K)
+#     g (1024*m), G (1000*M)
+#     t (1024*g), T (1000*G)
+# max-output-size=0
 
 # C-DNS output file pattern.
 # output=

--- a/src/blockcborwriter.cpp
+++ b/src/blockcborwriter.cpp
@@ -62,16 +62,14 @@ void BlockCborWriter::writeAE(const std::shared_ptr<AddressEvent>& ae,
 void BlockCborWriter::checkForRotation(const std::chrono::system_clock::time_point& timestamp)
 {
     if ( !enc_->is_open() ||
-         output_pattern_.need_rotate(timestamp,
-                                     config_,
-                                     config_.max_blocks_in_file > 0 &&
-                                     blocks_in_file_ >= config_.max_blocks_in_file) )
+         ( config_.max_output_size.size > 0 &&
+           enc_->bytes_written() >= config_.max_output_size.size ) ||
+         output_pattern_.need_rotate(timestamp, config_) )
     {
         close();
         filename_ = output_pattern_.filename(timestamp, config_);
         enc_->open(filename_);
         writeFileHeader();
-        blocks_in_file_ = 0;
     }
 }
 
@@ -370,5 +368,4 @@ void BlockCborWriter::writeBlock()
     data_->last_packet_statistics = last_end_block_statistics_;
     data_->writeCbor(*enc_);
     data_->clear();
-    blocks_in_file_++;
 }

--- a/src/blockcborwriter.cpp
+++ b/src/blockcborwriter.cpp
@@ -61,12 +61,17 @@ void BlockCborWriter::writeAE(const std::shared_ptr<AddressEvent>& ae,
 
 void BlockCborWriter::checkForRotation(const std::chrono::system_clock::time_point& timestamp)
 {
-    if ( !enc_->is_open() || output_pattern_.need_rotate(timestamp, config_) )
+    if ( !enc_->is_open() ||
+         output_pattern_.need_rotate(timestamp,
+                                     config_,
+                                     config_.max_blocks_in_file > 0 &&
+                                     blocks_in_file_ >= config_.max_blocks_in_file) )
     {
         close();
         filename_ = output_pattern_.filename(timestamp, config_);
         enc_->open(filename_);
         writeFileHeader();
+        blocks_in_file_ = 0;
     }
 }
 
@@ -365,4 +370,5 @@ void BlockCborWriter::writeBlock()
     data_->last_packet_statistics = last_end_block_statistics_;
     data_->writeCbor(*enc_);
     data_->clear();
+    blocks_in_file_++;
 }

--- a/src/blockcborwriter.hpp
+++ b/src/blockcborwriter.hpp
@@ -14,6 +14,7 @@
 #define BLOCKEDCBORWRITER_HPP
 
 #include <chrono>
+#include <cstdint>
 #include <memory>
 
 #include "baseoutputwriter.hpp"
@@ -192,9 +193,9 @@ private:
     std::string filename_;
 
     /**
-     * \brief the number of blocks in the file to date.
+     * \brief bytes written to this file so far.
      */
-    unsigned blocks_in_file_;
+    std::uintmax_t bytes_written_;
 
     /**
      * \brief the output CBOR encoder.

--- a/src/blockcborwriter.hpp
+++ b/src/blockcborwriter.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 Internet Corporation for Assigned Names and Numbers.
+ * Copyright 2016-2018 Internet Corporation for Assigned Names and Numbers.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -45,6 +45,7 @@ public:
      */
     BlockCborWriter(const Configuration& config,
                       std::unique_ptr<CborBaseStreamFileEncoder> enc);
+
     /**
      * \brief Destructor.
      *
@@ -189,6 +190,11 @@ private:
      * \brief the final current filename.
      */
     std::string filename_;
+
+    /**
+     * \brief the number of blocks in the file to date.
+     */
+    unsigned blocks_in_file_;
 
     /**
      * \brief the output CBOR encoder.

--- a/src/cborencoder.hpp
+++ b/src/cborencoder.hpp
@@ -253,6 +253,11 @@ public:
      */
     virtual const char* suggested_extension() = 0;
 
+    /**
+     * \brief Count of the bytes written since opening.
+     */
+    virtual std::uintmax_t bytes_written() = 0;
+
 protected:
     /**
      * \brief Write all accumulated output to the file.
@@ -302,6 +307,7 @@ public:
             throw std::runtime_error("Can't open file when one already open.");
 
         writer_ = make_unique<Writer>(name, level_);
+        bytes_written_ = 0;
     }
 
     /**
@@ -332,6 +338,14 @@ public:
         return Writer::suggested_extension();
     }
 
+    /**
+     * \brief Count of the bytes written since opening.
+     */
+    virtual std::uintmax_t bytes_written()
+    {
+        return bytes_written_;
+    }
+
 protected:
     /**
      * \brief Write all accumulated output to the file.
@@ -345,6 +359,7 @@ protected:
             throw std::runtime_error("Can't write to file when not open.");
 
         writer_->writeBytes(p, n_bytes);
+        bytes_written_ += n_bytes;
     }
 
 private:
@@ -357,6 +372,11 @@ private:
      * \brief The compression level, if used.
      */
     unsigned level_;
+
+    /**
+     * \brief The number of bytes written.
+     */
+    std::uintmax_t bytes_written_;
 };
 
 /**

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 Internet Corporation for Assigned Names and Numbers.
+ * Copyright 2016-2018 Internet Corporation for Assigned Names and Numbers.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -194,6 +194,7 @@ Configuration::Configuration()
       promisc_mode(false),
       output_options_queries(0), output_options_responses(0),
       max_block_qr_items(5000),
+      max_blocks_in_file(0),
       report_info(false), log_network_stats_period(0),
       debug_dns(false), debug_qr(false), omit_sysid(false),
       max_channel_size(10000),
@@ -275,6 +276,9 @@ Configuration::Configuration()
         ("max-block-qr-items",
          po::value<unsigned int>(&max_block_qr_items)->default_value(5000),
          "maximum number of query/response items in an output block.")
+        ("max-blocks-in-file",
+         po::value<unsigned int>(&max_blocks_in_file)->default_value(0),
+         "maximum number of blocks in an output file.")
         ("output,o",
          po::value<std::string>(&output_pattern),
          "filename pattern for storing C-DNS output.")
@@ -378,6 +382,7 @@ void Configuration::dump_config(std::ostream& os) const
        << "  Skew timeout         : " << skew_timeout << " microseconds\n"
        << "  Snap length          : " << snaplen << "\n"
        << "  Max block items      : " << max_block_qr_items << "\n"
+       << "  Max blocks in file   : " << max_blocks_in_file << "\n"
        << "  File rotation period : " << rotation_period << "\n"
        << "  Promiscuous mode     : " << (promisc_mode ? "On" : "Off") << "\n"
        << "  Capture interfaces   : ";

--- a/src/configuration.hpp
+++ b/src/configuration.hpp
@@ -13,12 +13,37 @@
 #ifndef CONFIGURATION_HPP
 #define CONFIGURATION_HPP
 
+#include <cstdint>
 #include <string>
 #include <vector>
 
 #include <boost/program_options.hpp>
 
 #include "ipaddress.hpp"
+
+/**
+ * \struct Size
+ * \brief A value holding a size, an unsigned number that may be specified
+ * with a suffix of k, K, m, M, g, G, t, T.
+ */
+struct Size
+{
+public:
+    Size() : size(0) {}
+    Size(std::uintmax_t n) : size(n) {}
+    std::uintmax_t size;
+};
+
+/**
+ * \brief Overload <code>validate()</code> for Size.
+ *
+ * @param v             holder for result.
+ * @param values        input values.
+ * @param val1          compiler workaround.
+ * @param val2          compiler workaround.
+ */
+void validate(boost::any& v, const std::vector<std::string>& values,
+              Size* val1, int val2);
 
 /**
  * \class Configuration
@@ -202,9 +227,9 @@ public:
     unsigned int max_block_qr_items;
 
     /**
-     * \brief set the maximum number of blocks in a file. 0 = no limit.
+     * \brief set the maximum uncompressed output size. 0 = no limit.
      */
-    unsigned int max_blocks_in_file;
+    Size max_output_size;
 
     /**
      * \brief which RR types are to be included on output.

--- a/src/configuration.hpp
+++ b/src/configuration.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 Internet Corporation for Assigned Names and Numbers.
+ * Copyright 2016-2018 Internet Corporation for Assigned Names and Numbers.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -200,6 +200,11 @@ public:
      * \brief set the maximum number of query/response items in a block.
      */
     unsigned int max_block_qr_items;
+
+    /**
+     * \brief set the maximum number of blocks in a file. 0 = no limit.
+     */
+    unsigned int max_blocks_in_file;
 
     /**
      * \brief which RR types are to be included on output.

--- a/src/rotatingfilename.cpp
+++ b/src/rotatingfilename.cpp
@@ -55,12 +55,12 @@ namespace {
 }
 
 bool RotatingFileName::need_rotate(const std::chrono::system_clock::time_point& t,
-                                   const Configuration& config, bool force)
+                                   const Configuration& config)
 {
     if ( t < next_check_ )
         return false;
 
-    if ( t >= next_rot_ || force )
+    if ( t >= next_rot_ )
     {
         // Generate new base filename and see if it's changed.
         std::string new_base = baseFilename(t, config);

--- a/src/rotatingfilename.hpp
+++ b/src/rotatingfilename.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 Internet Corporation for Assigned Names and Numbers.
+ * Copyright 2016-2018 Internet Corporation for Assigned Names and Numbers.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -59,10 +59,11 @@ public:
      *
      * \param t      the new time point.
      * \param config the current configuration.
+     * \param force  force rotation if possible.
      * \returns `true` if a file rotation is required.
      */
     bool need_rotate(const std::chrono::system_clock::time_point& t,
-                     const Configuration& config);
+                     const Configuration& config, bool force=false);
 
     /**
      * \brief Generate the filename with time/date items at the specified time.
@@ -107,9 +108,14 @@ protected:
 
 private:
     /**
-     * \brief time for the next rotation check.
+     * \brief time for the next rotation.
      */
     std::chrono::system_clock::time_point next_rot_;
+
+    /**
+     * \brief next time to check rotation.
+     */
+    std::chrono::system_clock::time_point next_check_;
 
     /**
      * \brief the rotation period.

--- a/src/rotatingfilename.hpp
+++ b/src/rotatingfilename.hpp
@@ -54,16 +54,14 @@ public:
      *
      * If the rotation period has expired, a rotation is needed if the
      * filename generated from the pattern has changed. If the filename
-     * has not changed, allow another rotation period to elapse before
-     * checking again.
+     * has not changed, allow a second to elapse before checking again.
      *
      * \param t      the new time point.
      * \param config the current configuration.
-     * \param force  force rotation if possible.
      * \returns `true` if a file rotation is required.
      */
     bool need_rotate(const std::chrono::system_clock::time_point& t,
-                     const Configuration& config, bool force=false);
+                     const Configuration& config);
 
     /**
      * \brief Generate the filename with time/date items at the specified time.

--- a/test-scripts/output-size-limit.sh
+++ b/test-scripts/output-size-limit.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# Check max-file-qr-items works.
+
+COMP=./compactor
+DATAFILE=./dns.pcap
+
+tmpdir=`mktemp -d -t "file-size-limit.XXXXXX"`
+
+cleanup()
+{
+    rm -rf $tmpdir
+    exit $1
+}
+
+trap "cleanup 1" HUP INT TERM
+
+# Run compactor twice, once with block count limit.
+$COMP -c /dev/null -o "$tmpdir/out.cbor" $DATAFILE
+if [ $? -ne 0 ]; then
+    cleanup 1
+fi
+
+$COMP -c /dev/null --max-output-size 10k --max-block-qr-items 100 -o "$tmpdir/out2.cbor" $DATAFILE
+if [ $? -ne 0 ]; then
+    cleanup 1
+fi
+
+# There should be one out file and 3 out2 files.
+NOUT=$(ls $tmpdir/out.cbor* | wc -l)
+NOUT2=$(ls $tmpdir/out2.cbor* | wc -l)
+if [ $NOUT -eq 1 -a $NOUT2 -eq 5 ]; then
+    cleanup 0
+fi
+cleanup 1

--- a/tests/rotatingfilename_test.cpp
+++ b/tests/rotatingfilename_test.cpp
@@ -59,12 +59,6 @@ SCENARIO("Rotating file name changes", "[rotation]")
             t += std::chrono::seconds(20);
             REQUIRE(!rfn.need_rotate(t, config));
         }
-        AND_THEN("check rotation is needed in time period if forced")
-        {
-            REQUIRE(rfn.filename(t, config) == "19891227-000000.test");
-            t += std::chrono::seconds(20);
-            REQUIRE(rfn.need_rotate(t, config, true));
-        }
 
         AND_THEN("check rotation is needed after time period")
         {

--- a/tests/rotatingfilename_test.cpp
+++ b/tests/rotatingfilename_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 Internet Corporation for Assigned Names and Numbers.
+ * Copyright 2016-2018 Internet Corporation for Assigned Names and Numbers.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -58,6 +58,12 @@ SCENARIO("Rotating file name changes", "[rotation]")
             REQUIRE(rfn.filename(t, config) == "19891227-000000.test");
             t += std::chrono::seconds(20);
             REQUIRE(!rfn.need_rotate(t, config));
+        }
+        AND_THEN("check rotation is needed in time period if forced")
+        {
+            REQUIRE(rfn.filename(t, config) == "19891227-000000.test");
+            t += std::chrono::seconds(20);
+            REQUIRE(rfn.need_rotate(t, config, true));
         }
 
         AND_THEN("check rotation is needed after time period")


### PR DESCRIPTION
Once the limit it reached, it triggers a file rotation, if one is
possible.

This change makes a small change to file rotation semantics. Previously,
if a rotation was due but the name did not change, the rotation was
reconsidered only after another rotation period. Now if a rotation fails
because the file name did not change, the file pattern is checked every
subsequent second for a change.