### PR TITLE
Added file rotation SIGUSR1 handling for dnstap socket

### DIFF
--- a/src/compactor.cpp
+++ b/src/compactor.cpp
@@ -774,11 +774,19 @@ static int run_configuration(const po::variables_map& vm,
                     [&](int signal)
                     {
                         signal_received = signal;
-                        dnstap.breakloop();
-                        acceptor.cancel();
-                        service.stop();
-                        ::pthread_kill(my_thread, SIGUSR2);
+                        if (signal_received != SIGUSR1) {
+                          dnstap.breakloop();
+                          acceptor.cancel();
+                          service.stop();
+                          ::pthread_kill(my_thread, SIGUSR2);
+                        } else {
+                          LOG_INFO << "Forcing C-DNS file rotation on SIGUSR1";
+                          CborItem empty_cbi;
+                          output.cbor->put(empty_cbi, true);
+                        }
                     });
+
+
 
                 std::function<void (const boost::system::error_code&)> handle_accept = [&](const boost::system::error_code&)
                 {

--- a/src/compactor.cpp
+++ b/src/compactor.cpp
@@ -786,8 +786,6 @@ static int run_configuration(const po::variables_map& vm,
                         }
                     });
 
-
-
                 std::function<void (const boost::system::error_code&)> handle_accept = [&](const boost::system::error_code&)
                 {
                     if ( signal_received == 0 )


### PR DESCRIPTION
Linked to issue https://github.com/dns-stats/compactor/issues/82, forcing file rotation using SIGUSR1 was only implemented for traffic capture on network interface. This PR adds the same functionnality for dnstap-socket.